### PR TITLE
feat(report): add PDF report generation for transactions and gifts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "pdfmake": "^0.3.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "xlsx": "^0.18.5"
@@ -32,6 +33,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/swagger": "^7.4.0",
+        "@types/estree": "^1.0.8",
         "@types/express": "^4.17.17",
         "@types/multer": "^1.4.12",
         "@types/node": "^20.3.1",
@@ -2805,6 +2807,21 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2908,10 +2925,11 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -3969,7 +3987,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4094,6 +4111,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -4761,6 +4787,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -4880,6 +4912,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -5658,8 +5696,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -6054,6 +6091,32 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
@@ -7866,6 +7929,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8151,6 +8220,25 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -8997,6 +9085,12 @@
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "dev": true
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9155,6 +9249,33 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pdfkit": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
+      "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.0.tgz",
+      "integrity": "sha512-sS7ow3ZrdFjlC7s4J5k3UA5IHQQbXRs6+NtdzfWDR0SvPa7+M8d69rITObFAsJ4t6iwkKRsc87Q+I/gFlTUVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.17.2",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
@@ -9260,6 +9381,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9736,6 +9862,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -9892,6 +10024,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -10649,6 +10787,12 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -10991,6 +11135,26 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -11394,6 +11558,18 @@
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "pdfmake": "^0.3.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "xlsx": "^0.18.5"
@@ -38,6 +39,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/swagger": "^7.4.0",
+    "@types/estree": "^1.0.8",
     "@types/express": "^4.17.17",
     "@types/multer": "^1.4.12",
     "@types/node": "^20.3.1",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -154,7 +154,7 @@ export class AuthService {
             });
             if (customer)
                 throw new ConflictException(
-                  'Customer with the same customer number already exist in system!'
+                    'Customer with the same customer number already exist in system!'
                 );
         } else {
             data.odooCustomerId = await this.personService.getLastOdooCustomerId();

--- a/src/modules/person/person.controller.ts
+++ b/src/modules/person/person.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import {
+    Body,
+    ConflictException,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    Query,
+} from '@nestjs/common';
 import {
     ApiBadRequestResponse,
     ApiBearerAuth,

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -142,4 +142,28 @@ export class TransactionController {
         res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
         res.send(buffer);
     }
+
+    /*******************************************************************
+     * report-pdf - Download PDF report
+     ******************************************************************/
+    @Public()
+    @ApiUnauthorizedResponse({ description: 'Unauthorized!' })
+    @ApiOkResponse({ description: 'PDF file downloaded successfully' })
+    @ApiInternalServerErrorResponse({ description: 'Unexpected Error' })
+    @ApiOperation({
+        summary: 'Download transaction report as PDF file',
+        description: `Generates a printable PDF report of transactions filtered by date range and optional type (${Object.values(TransactionType).join(', ')})`,
+    })
+    @ApiBody({ type: TransactionReportDto })
+    @Post('report-pdf')
+    async downloadPDFReport(@Body() data: TransactionReportDto, @Res() res: Response) {
+        const buffer = await this.service.generatePDFReport(data);
+
+        const filename = `transactions_${data.startDate}_to_${data.endDate}.pdf`;
+
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        res.setHeader('Content-Length', buffer.length);
+        res.end(buffer);
+    }
 }

--- a/src/modules/transaction/transaction.module.ts
+++ b/src/modules/transaction/transaction.module.ts
@@ -5,6 +5,7 @@ import { Transaction, TransactionSchema } from './schema/transaction.schema';
 import { Global, Module } from '@nestjs/common';
 import { PersonModule } from '../person/person.module';
 import { NotificationModule } from '../notification/notification.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @Global()
 @Module({
@@ -12,6 +13,7 @@ import { NotificationModule } from '../notification/notification.module';
         MongooseModule.forFeature([{ name: Transaction.name, schema: TransactionSchema }]),
         PersonModule,
         NotificationModule,
+        SharedModule,
     ],
     controllers: [TransactionController],
     providers: [TransactionService],

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -12,13 +12,15 @@ import { TransactionType } from './enum/type.enum';
 import { InjectModel } from '@nestjs/mongoose';
 import mongoose, { Model } from 'mongoose';
 import * as XLSX from 'xlsx';
+import { PDFGeneratorService } from '../../shared/services/pdf-generator.service';
 
 @Injectable()
 export class TransactionService {
     constructor(
         @InjectModel(Transaction.name) private readonly model: Model<TransactionDocument>,
         private readonly notificationService: NotificationService,
-        private readonly personService: PersonService
+        private readonly personService: PersonService,
+        private readonly pdfGeneratorService: PDFGeneratorService
     ) {}
 
     /*******************************************************************
@@ -204,7 +206,7 @@ export class TransactionService {
     }
 
     /*******************************************************************
-     * generateReport
+     * generateReport (Excel)
      ******************************************************************/
     async generateReport(data: TransactionReportDto): Promise<Buffer> {
         const { startDate, endDate, type } = data;
@@ -248,5 +250,71 @@ export class TransactionService {
         const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
 
         return buffer;
+    }
+
+    /*******************************************************************
+     * generatePDFReport
+     ******************************************************************/
+    async generatePDFReport(data: TransactionReportDto): Promise<Buffer> {
+        const { startDate, endDate, type } = data;
+
+        const query: any = {
+            createdAt: {
+                $gte: new Date(startDate),
+                $lte: new Date(endDate),
+            },
+        };
+
+        if (type) {
+            query.type = type;
+        }
+
+        const transactions = await this.model
+            .find(query)
+            .populate('user', 'name phone email')
+            .populate('performedBy', 'name phone')
+            .sort({ createdAt: -1 })
+            .exec();
+
+        // Calculate total points
+        const totalPoints = transactions.reduce((sum, t: any) => sum + (t.points || 0), 0);
+
+        // Transform data for PDF
+        const reportData = transactions.map((transaction: any) => ({
+            transactionId: transaction._id.toString(),
+            customerName: transaction.user?.name || 'N/A',
+            customerPhone: transaction.customerPhone || transaction.user?.phone || 'N/A',
+            invoiceNo: transaction.invoiceNo || 'N/A',
+            amount: transaction.amount || 0,
+            points: transaction.points || 0,
+            type: transaction.type,
+            details: transaction.details || 'N/A',
+            performedBy: transaction.performedBy?.name || 'N/A',
+            createdAt: transaction.createdAt,
+        }));
+
+        // Generate PDF
+        return this.pdfGeneratorService.generateReport({
+            title: 'Transaction Report',
+            companyName: 'Superior Rewards',
+            generatedDate: new Date(),
+            startDate: new Date(startDate),
+            endDate: new Date(endDate),
+            columns: [
+                { key: 'transactionId', label: 'Transaction ID', width: '12%' },
+                { key: 'customerName', label: 'Customer Name', width: '12%' },
+                { key: 'customerPhone', label: 'Phone', width: '10%' },
+                { key: 'invoiceNo', label: 'Invoice No', width: '10%' },
+                { key: 'amount', label: 'Amount', width: '8%' },
+                { key: 'points', label: 'Points', width: '8%' },
+                { key: 'type', label: 'Type', width: '8%' },
+                { key: 'details', label: 'Details', width: '12%' },
+                { key: 'performedBy', label: 'Performed By', width: '10%' },
+                { key: 'createdAt', label: 'Date', width: '10%' },
+            ],
+            data: reportData,
+            totalPoints: totalPoints,
+            footerText: `Report for transactions from ${new Date(startDate).toLocaleDateString()} to ${new Date(endDate).toLocaleDateString()}`,
+        });
     }
 }

--- a/src/modules/user-gift/user-gift.controller.ts
+++ b/src/modules/user-gift/user-gift.controller.ts
@@ -229,4 +229,28 @@ export class UserGiftController {
         res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
         res.send(buffer);
     }
+
+    /*******************************************************************
+     * report-pdf - Download PDF report
+     ******************************************************************/
+    @Public()
+    @ApiUnauthorizedResponse({ description: 'Unauthorized!' })
+    @ApiOkResponse({ description: 'PDF file downloaded successfully' })
+    @ApiInternalServerErrorResponse({ description: 'Unexpected Error' })
+    @ApiOperation({
+        summary: 'Download user gifts report as PDF file',
+        description: `Generates a printable PDF report of user gift redemptions filtered by date range and optional status (${Object.values(UserGiftStatus).join(', ')}). Includes monetary value and total points summary.`,
+    })
+    @ApiBody({ type: UserGiftReportDto })
+    @Post('report-pdf')
+    async downloadPDFReport(@Body() data: UserGiftReportDto, @Res() res: Response) {
+        const buffer = await this.service.generatePDFReport(data);
+
+        const filename = `user_gifts_${data.startDate}_to_${data.endDate}.pdf`;
+
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        res.setHeader('Content-Length', buffer.length);
+        res.end(buffer);
+    }
 }

--- a/src/modules/user-gift/user-gift.module.ts
+++ b/src/modules/user-gift/user-gift.module.ts
@@ -9,6 +9,7 @@ import { GiftModule } from '../gift/gift.module';
 import { UserGiftTtlModule } from '../user-gift-ttl/user-gift-ttl.module';
 import { SettingModule } from '../settings/setting.module';
 import { NotificationModule } from '../notification/notification.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @Global()
 @Module({
@@ -25,6 +26,7 @@ import { NotificationModule } from '../notification/notification.module';
         forwardRef(() => UserGiftTtlModule),
         SettingModule,
         NotificationModule,
+        SharedModule,
     ],
     controllers: [UserGiftController],
     providers: [UserGiftService],

--- a/src/modules/user-gift/user-gift.service.ts
+++ b/src/modules/user-gift/user-gift.service.ts
@@ -30,6 +30,7 @@ import { UserGiftStatus } from './enum/status.enum';
 import { helper } from '../../utils/helper';
 import * as process from 'process';
 import * as XLSX from 'xlsx';
+import { PDFGeneratorService } from '../../shared/services/pdf-generator.service';
 
 @Injectable()
 export class UserGiftService {
@@ -40,7 +41,8 @@ export class UserGiftService {
         private readonly notificationService: NotificationService,
         private readonly transactionService: TransactionService,
         private readonly SettingService: SettingService,
-        private readonly personService: PersonService
+        private readonly personService: PersonService,
+        private readonly pdfGeneratorService: PDFGeneratorService
     ) {}
 
     /*******************************************************************
@@ -472,7 +474,7 @@ export class UserGiftService {
     }
 
     /*******************************************************************
-     * generateReport
+     * generateReport (Excel)
      ******************************************************************/
     async generateReport(data: UserGiftReportDto): Promise<Buffer> {
         const { startDate, endDate, status } = data;
@@ -529,5 +531,85 @@ export class UserGiftService {
         const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
 
         return buffer;
+    }
+
+    /*******************************************************************
+     * generatePDFReport
+     ******************************************************************/
+    async generatePDFReport(data: UserGiftReportDto): Promise<Buffer> {
+        const { startDate, endDate, status } = data;
+
+        const query: any = {
+            createdAt: {
+                $gte: new Date(startDate),
+                $lte: new Date(endDate),
+            },
+        };
+
+        if (status) {
+            query.status = status;
+        }
+
+        const userGifts = await this.model
+            .find(query)
+            .populate('user', 'name phone email')
+            .populate('gifts', 'name points')
+            .populate('redeemedBy', 'name phone')
+            .populate('performedBy', 'name phone')
+            .sort({ createdAt: -1 })
+            .exec();
+
+        const settings = await this.SettingService.fetch();
+        const pointsToAmountRatio = settings?.points || 1;
+
+        // Calculate total points
+        const totalPoints = userGifts.reduce((sum, g: any) => sum + (g.totalPoints || 0), 0);
+
+        // Transform data for PDF
+        const reportData = userGifts.map((userGift: any) => {
+            const giftNames = userGift.gifts?.map((g: any) => g?.name || 'N/A').join(', ') || 'N/A';
+            const monetaryValue = userGift.totalPoints / pointsToAmountRatio;
+
+            return {
+                redemptionId: userGift._id.toString(),
+                customerName: userGift.user?.name || 'N/A',
+                customerPhone: userGift.user?.phone || 'N/A',
+                customerEmail: userGift.user?.email || 'N/A',
+                gifts: giftNames,
+                totalPoints: userGift.totalPoints || 0,
+                monetaryValue: monetaryValue || 0,
+                status: userGift.status,
+                isExpired: userGift.isExpired ? 'Yes' : 'No',
+                qrCode: userGift.qrCode || 'N/A',
+                redeemedBy: userGift.redeemedBy?.name || 'N/A',
+                performedBy: userGift.performedBy?.name || 'N/A',
+                createdAt: userGift.createdAt,
+                updatedAt: userGift.updatedAt,
+            };
+        });
+
+        // Generate PDF
+        return this.pdfGeneratorService.generateReport({
+            title: 'Gift Redemption Report',
+            companyName: 'Superior Rewards',
+            generatedDate: new Date(),
+            startDate: new Date(startDate),
+            endDate: new Date(endDate),
+            columns: [
+                { key: 'redemptionId', label: 'Redemption ID', width: '11%' },
+                { key: 'customerName', label: 'Customer Name', width: '12%' },
+                { key: 'customerPhone', label: 'Phone', width: '10%' },
+                { key: 'gifts', label: 'Gifts', width: '15%' },
+                { key: 'totalPoints', label: 'Points', width: '8%' },
+                { key: 'monetaryValue', label: 'Monetary Value', width: '10%' },
+                { key: 'status', label: 'Status', width: '9%' },
+                { key: 'isExpired', label: 'Expired', width: '7%' },
+                { key: 'redeemedBy', label: 'Redeemed By', width: '11%' },
+                { key: 'createdAt', label: 'Date', width: '7%' },
+            ],
+            data: reportData,
+            totalPoints: totalPoints,
+            footerText: `Report for gift redemptions from ${new Date(startDate).toLocaleDateString()} to ${new Date(endDate).toLocaleDateString()}`,
+        });
     }
 }

--- a/src/shared/services/pdf-generator.service.ts
+++ b/src/shared/services/pdf-generator.service.ts
@@ -1,0 +1,256 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+let pdfMake: any;
+
+try {
+    // Dynamic require to avoid module resolution issues
+    const pdfMakeModule = require('pdfmake/build/pdfmake');
+    const pdfFontsModule = require('pdfmake/build/vfs_fonts');
+
+    pdfMake = pdfMakeModule;
+    if (pdfFontsModule?.pdfMake?.vfs) {
+        pdfMake.vfs = pdfFontsModule.pdfMake.vfs;
+    }
+} catch {
+    // If standard import fails, try alternative
+    pdfMake = require('pdfmake');
+}
+
+export interface PDFReportConfig {
+    title: string;
+    companyName: string;
+    generatedDate: Date;
+    startDate: Date;
+    endDate: Date;
+    columns: Array<{
+        key: string;
+        label: string;
+        width?: string;
+    }>;
+    data: Record<string, any>[];
+    footerText?: string;
+    totalPoints?: number;
+    pageSize?: string | { width: number; height: number };
+    pageOrientation?: 'portrait' | 'landscape';
+    pageMargins?: [number, number, number, number];
+}
+
+@Injectable()
+export class PDFGeneratorService {
+    private readonly logger = new Logger(PDFGeneratorService.name);
+
+    async generateReport(config: PDFReportConfig): Promise<Buffer> {
+        try {
+            const docDefinition = this.buildReportDefinition(config);
+            const doc = pdfMake.createPdf(docDefinition);
+            return await doc.getBuffer();
+        } catch (error) {
+            this.logger.error('Error generating PDF report:', error);
+            throw error;
+        }
+    }
+
+    private buildReportDefinition(config: PDFReportConfig): any {
+        const {
+            title,
+            companyName,
+            generatedDate,
+            startDate,
+            endDate,
+            columns,
+            data,
+            footerText,
+            totalPoints,
+            pageSize = {
+                width: 1440,
+                height: 900,
+            },
+            pageOrientation = 'landscape',
+            pageMargins = [20, 20, 20, 40],
+        } = config;
+
+        // Format dates
+        const formattedGeneratedDate = this.formatDate(generatedDate);
+        const formattedStartDate = this.formatDate(startDate);
+        const formattedEndDate = this.formatDate(endDate);
+
+        // Build table header
+        const tableHeaders = columns.map((col) => ({
+            text: col.label,
+            fillColor: '#17498E',
+            color: '#FFFFFF',
+            alignment: 'center',
+            margin: [5, 5, 5, 5],
+            fontSize: 11,
+            bold: true,
+        }));
+
+        // Build table body
+        const tableBody = [tableHeaders];
+        for (const row of data) {
+            const rowData = columns.map((col) => {
+                let value = row[col.key] || 'N/A';
+                // Format dates in the table
+                if (value instanceof Date) {
+                    value = this.formatDate(value);
+                }
+                // Format numbers
+                if (typeof value === 'number' && col.key !== 'Type') {
+                    value =
+                        typeof value === 'number' && col.key.toLowerCase().includes('date')
+                            ? value
+                            : this.formatNumber(value);
+                }
+                return {
+                    text: String(value),
+                    bold: false,
+                    fillColor: '',
+                    color: '#000000',
+                    alignment: ['Amount', 'Points'].includes(col.label) ? 'right' : 'left',
+                    margin: [5, 3, 5, 3],
+                    fontSize: 9,
+                };
+            });
+            tableBody.push(rowData);
+        }
+
+        // Build document content
+        const content: any[] = [
+            // Header
+            {
+                text: companyName,
+                fontSize: 18,
+                color: '#17498E',
+                bold: true,
+                alignment: 'center',
+                margin: [0, 0, 0, 5],
+            },
+            {
+                text: title,
+                fontSize: 14,
+                bold: true,
+                alignment: 'center',
+                margin: [0, 0, 0, 15],
+            },
+
+            // Report metadata
+            {
+                columns: [
+                    {
+                        text: `Report Generated: ${formattedGeneratedDate}`,
+                        fontSize: 10,
+                        bold: true,
+                    },
+                    {
+                        text: `Date Range: ${formattedStartDate} to ${formattedEndDate}`,
+                        fontSize: 10,
+                        bold: true,
+                        alignment: 'right',
+                    },
+                ],
+                margin: [0, 0, 0, 15],
+            },
+
+            // Table
+            {
+                table: {
+                    headerRows: 1,
+                    widths: this.calculateColumnWidths(columns),
+                    body: tableBody,
+                },
+                layout: {
+                    hLineWidth: (i: number) => (i === 1 ? 2 : 1),
+                    hLineColor: (i: number) => (i === 1 ? '#17498E' : '#CCCCCC'),
+                    vLineWidth: () => 1,
+                    vLineColor: () => '#CCCCCC',
+                    paddingLeft: () => 5,
+                    paddingRight: () => 5,
+                    paddingTop: () => 3,
+                    paddingBottom: () => 3,
+                },
+                margin: [0, 0, 0, 20],
+            },
+        ];
+
+        // Add summary if totalPoints is provided
+        if (totalPoints !== undefined) {
+            content.push({
+                columns: [
+                    { text: '' },
+                    {
+                        text: [
+                            {
+                                text: 'Total Points: ',
+                                fontSize: 11,
+                                bold: true,
+                            },
+                            {
+                                text: this.formatNumber(totalPoints),
+                                fontSize: 12,
+                                color: '#27AE60',
+                                bold: true,
+                            },
+                        ],
+                        alignment: 'right',
+                    },
+                ],
+                margin: [0, 10, 0, 0],
+            });
+        }
+
+        // Add footer text if provided
+        if (footerText) {
+            content.push({
+                text: footerText,
+                fontSize: 8,
+                bold: true,
+                color: '#7F8C8D',
+                alignment: 'center',
+                margin: [0, 20, 0, 0],
+            });
+        }
+
+        return {
+            pageSize: pageSize,
+            pageOrientation: pageOrientation,
+            pageMargins: pageMargins,
+            content: content,
+            footer: (currentPage: number, pageCount: number) => ({
+                text: `Page ${currentPage} of ${pageCount}`,
+                alignment: 'center',
+                fontSize: 8,
+                bold: true,
+                color: '#7F8C8D',
+                margin: [0, 10, 0, 0],
+            }),
+            defaultStyle: {
+                size: 9,
+            },
+        };
+    }
+
+    private formatDate(date: Date): string {
+        if (!date) return '';
+        const d = new Date(date);
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        const year = d.getFullYear();
+        return `${year}-${month}-${day}`;
+    }
+
+    private formatNumber(value: number): string {
+        if (typeof value !== 'number') return String(value);
+        return value.toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+
+    private calculateColumnWidths(
+        columns: Array<{ key: string; label: string; width?: string }>
+    ): string[] {
+        // If widths are specified, use them; otherwise distribute evenly
+        const widths = columns.map((col) => col.width || '*');
+        return widths;
+    }
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PDFGeneratorService } from './services/pdf-generator.service';
+
+@Module({
+    providers: [PDFGeneratorService],
+    exports: [PDFGeneratorService],
+})
+export class SharedModule {}


### PR DESCRIPTION
Introduces a new feature to download reports in PDF format for both transactions and user gift redemptions.

A reusable `PDFGeneratorService` has been created within a new `SharedModule` to handle the core logic of PDF creation using the 'pdfmake' library.

New endpoints have been added:
- `POST /transactions/report-pdf`
- `POST /user-gifts/report-pdf